### PR TITLE
close the box when the component unmounts

### DIFF
--- a/src/components/infoWindow.js
+++ b/src/components/infoWindow.js
@@ -17,6 +17,7 @@ const InfoWindow = React.createClass({
   },
 
   componentWillUnmount() {
+    this.close();
     this.removeListeners();
   },
 


### PR DESCRIPTION
Right now, if the infobox is removed from the gmaps children, it remains on the map. By calling close we remove it from the map.