### PR TITLE
Provide map instance and Maps API to callback

### DIFF
--- a/src/components/gmaps.js
+++ b/src/components/gmaps.js
@@ -56,7 +56,7 @@ const Gmaps = React.createClass({
       isMapCreated: true
     });
     if (this.props.onMapCreated) {
-      this.props.onMapCreated();
+      this.props.onMapCreated(this.map, google.maps);
     }
   },
 


### PR DESCRIPTION
That way there's no need to fish with the ref.