### PR TITLE
Re-organise browserify transform

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+src/
+demo/
+Procfile
+server.js

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "A Google Maps component for React.js",
   "main": "dist/index.js",
   "scripts": {
+    "prepublish": "npm run build",
     "build": "babel ./src --out-dir ./dist",
     "pretest": "eslint ./src",
     "test": "jest",
-    "demo": "browserify ./demo/index.js -o ./demo/build.js",
+    "demo": "browserify -t babelify ./demo/index.js -o ./demo/build.js",
     "start": "node server"
   },
   "repository": {
@@ -36,13 +37,6 @@
     "express": "^4.11.2",
     "jest-cli": "^0.7.0",
     "react-addons-test-utils": "^0.14.2"
-  },
-  "browserify": {
-    "transform": [
-      [
-        "babelify"
-      ]
-    ]
   },
   "jest": {
     "testPathDirs": [


### PR DESCRIPTION
Move babelify transform out of browserify key in package.json. This
change is due to an error on deploy when requiring this module from a
project that uses a newer version of babel. This error is due to an
incompatability in the babelrc referencing an old key that isn't used by
babel 6.

Since this project exports the babel-ified version in the dist/ folder,
there isn't any need to run browserify or babelify over the code when using
it as a dependency in another project.

Add npmignore file to slim down production release. This file will ignore
any files not needed to use this module as a dependency.