### PR TITLE
Fix compatibility with React@16+

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const coords = {
 
 const params = {v: '3.exp', key: 'YOUR_API_KEY'};
 
-const App = React.createClass({
+class App extends React.Component {
 
   onMapCreated(map) {
     map.setOptions({
@@ -88,7 +88,7 @@ const App = React.createClass({
     );
   }
 
-});
+};
 
 ReactDOM.render(<App />, document.getElementById('gmaps'));
 ```

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import createReactClass from 'create-react-class';
 import {Gmaps} from '../dist';
 import MapEvents from '../dist/events/map';
 
@@ -13,7 +14,7 @@ const styles = {
   }
 };
 
-const App = React.createClass({
+const App = createReactClass({
 
   handler(_event) {
     const item = ReactDOM.findDOMNode(this.refs[_event]);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "express": "^4.11.2",
     "jest-cli": "^12.0.0",
     "react": "^15.0.1",
-    "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.0.1"
   },
   "jest": {
@@ -48,7 +47,6 @@
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/react",
       "<rootDir>/node_modules/react-dom",
-      "<rootDir>/node_modules/react-addons-test-utils",
       "<rootDir>/node_modules/create-react-class",
       "<rootDir>/node_modules/fbjs"
     ]

--- a/package.json
+++ b/package.json
@@ -49,10 +49,12 @@
       "<rootDir>/node_modules/react",
       "<rootDir>/node_modules/react-dom",
       "<rootDir>/node_modules/react-addons-test-utils",
+      "<rootDir>/node_modules/create-react-class",
       "<rootDir>/node_modules/fbjs"
     ]
   },
   "dependencies": {
+    "create-react-class": "^15.5.2",
     "object-assign": "^4.0.1"
   },
   "peerDependencies": {

--- a/src/components/__tests__/entity-test.js
+++ b/src/components/__tests__/entity-test.js
@@ -6,7 +6,7 @@ describe('Entity', () => {
 
   const React = require('react');
   const createReactClass = require('create-react-class');
-  const TestUtils = require('react-addons-test-utils');
+  const TestUtils = require('react-dom/test-utils');
   const createEntity = require('../entity');
   const Entity = createEntity('Entity', 'prop', {
     onClick: 'click'

--- a/src/components/__tests__/entity-test.js
+++ b/src/components/__tests__/entity-test.js
@@ -5,6 +5,7 @@ jest.dontMock('../entity');
 describe('Entity', () => {
 
   const React = require('react');
+  const createReactClass = require('create-react-class');
   const TestUtils = require('react-addons-test-utils');
   const createEntity = require('../entity');
   const Entity = createEntity('Entity', 'prop', {
@@ -85,7 +86,7 @@ describe('Entity', () => {
           setOptions: jest.genMockFunction()
         };
       };
-      const Parent = React.createClass({
+      const Parent = createReactClass({
         getInitialState() {
           return {
             prop: '1'
@@ -136,7 +137,7 @@ describe('Entity', () => {
           setOptions: jest.genMockFunction()
         };
       };
-      const Parent = React.createClass({
+      const Parent = createReactClass({
         getInitialState() {
           return {
             show: true
@@ -161,4 +162,3 @@ describe('Entity', () => {
   });
 
 });
-

--- a/src/components/__tests__/gmaps-test.js
+++ b/src/components/__tests__/gmaps-test.js
@@ -8,6 +8,7 @@ describe('Gmaps', () => {
 
   const React = require('react');
   const ReactDOM = require('react-dom');
+  const createReactClass = require('create-react-class');
   const TestUtils = require('react-addons-test-utils');
   const GoogleMaps = require('../../utils/google-maps');
   GoogleMaps.appendScript = () => {};
@@ -30,7 +31,7 @@ describe('Gmaps', () => {
     const onMapCreated = jest.genMockFunction();
 
     beforeEach(() => {
-      const Child = React.createClass({
+      const Child = createReactClass({
         render() {
           return null;
         }
@@ -117,7 +118,7 @@ describe('Gmaps', () => {
     });
 
     it('calls `setOptions` when receive new props', () => {
-      const Parent = React.createClass({
+      const Parent = createReactClass({
         getInitialState() {
           return {
             prop: '1'

--- a/src/components/__tests__/gmaps-test.js
+++ b/src/components/__tests__/gmaps-test.js
@@ -9,7 +9,7 @@ describe('Gmaps', () => {
   const React = require('react');
   const ReactDOM = require('react-dom');
   const createReactClass = require('create-react-class');
-  const TestUtils = require('react-addons-test-utils');
+  const TestUtils = require('react-dom/test-utils');
   const GoogleMaps = require('../../utils/google-maps');
   GoogleMaps.appendScript = () => {};
   const Gmaps = require('../gmaps');

--- a/src/components/entity.js
+++ b/src/components/entity.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Listener from '../mixins/listener';
 import compareProps from '../utils/compare-props';
 
 export default (name, latLngProp, events) => {
-  return React.createClass({
+  return createReactClass({
 
     mixins: [Listener],
 

--- a/src/components/gmaps.js
+++ b/src/components/gmaps.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import createReactClass from 'create-react-class';
 import objectAssign from 'object-assign';
 import MapEvents from '../events/map';
 import Listener from '../mixins/listener';
 import GoogleMaps from '../utils/google-maps';
 import compareProps from '../utils/compare-props';
 
-const Gmaps = React.createClass({
+const Gmaps = createReactClass({
 
   mixins: [Listener],
 


### PR DESCRIPTION
Hey!

Basically it's a migration from deprecated stuff (to get rid of annoying warnings). I think `create-react-class` should be a dependency rather than peer-dependency, but let me know what you think. Also, migration to ES6 classes can be considered in the future I guess.