### PR TITLE
added UNSAFE to componentWillReceiveProps methods to remove console warnings in React v16.3+

### DIFF
--- a/dist/components/entity.js
+++ b/dist/components/entity.js
@@ -39,7 +39,7 @@ exports['default'] = function (name, latLngProp, events) {
       this.addListeners(this.entity, events);
     },
 
-    componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps: function UNSAFE_componentWillReceiveProps(nextProps) {
       if (!(0, _utilsCompareProps2['default'])(this.props, nextProps)) {
         var options = this.getOptions(nextProps);
         this.entity.setOptions(options);

--- a/dist/components/gmaps.js
+++ b/dist/components/gmaps.js
@@ -63,7 +63,7 @@ var Gmaps = (0, _createReactClass2['default'])({
     this.removeListeners();
   },
 
-  componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps: function UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.map && !(0, _utilsCompareProps2['default'])(this.props, nextProps)) {
       this.map.setOptions(_extends({}, nextProps, {
         center: new google.maps.LatLng(nextProps.lat, nextProps.lng)

--- a/src/components/__tests__/gmaps-test.js
+++ b/src/components/__tests__/gmaps-test.js
@@ -113,7 +113,7 @@ describe('Gmaps', () => {
     it('does not call `setOptions` if maps are not loaded', () => {
       const gmaps = TestUtils.renderIntoDocument(<Gmaps />);
       expect(() => {
-        gmaps.componentWillReceiveProps({});
+        gmaps.UNSAFE_componentWillReceiveProps({});
       }).not.toThrow();
     });
 

--- a/src/components/entity.js
+++ b/src/components/entity.js
@@ -16,7 +16,7 @@ export default (name, latLngProp, events) => {
       this.addListeners(this.entity, events);
     },
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
       if (!compareProps(this.props, nextProps)) {
         const options = this.getOptions(nextProps);
         this.entity.setOptions(options);

--- a/src/components/gmaps.js
+++ b/src/components/gmaps.js
@@ -30,7 +30,7 @@ const Gmaps = createReactClass({
     this.removeListeners();
   },
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.map && !compareProps(this.props, nextProps)) {
       this.map.setOptions({
         ...nextProps,


### PR DESCRIPTION
Hi there,
I really love using this repository for my projects, but I noticed that it has not been updated in over 3 years. The map works really great, but there's a small problem on the method componentWillReceiveProps which has been deprecated since react v1.6.3. A warning keeps popping up in the console. So, following the react docs, I added  “UNSAFE_” to the methods, and it works fine when I tested it. Thanks
